### PR TITLE
created an npm package for the zap-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "type" : "git",
     "url" : "https://github.com/zen-audio-player/zap-cli.git"
   },
-  "private": true,
   "author": "Zen Audio Player",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
I needed to change this npm package so that it was no longer private in order to publish it to NPM. 

The link to this package can be found here - > [zap-cli npm registry](https://www.npmjs.com/package/zap-cli)
